### PR TITLE
Use AWS_PROFILE env value as default profile

### DIFF
--- a/exe/traceroute53
+++ b/exe/traceroute53
@@ -161,7 +161,7 @@ end
 def main
   opt = OptionParser.new("usage: traceroute53 <domain>")
 
-  profile = nil
+  profile = ENV['AWS_PROFILE']
   opt.on('--profile PROFILE', "use given profile") {|v| profile = v }
 
   opt.parse!(ARGV)


### PR DESCRIPTION
```console
$ export AWS_PROFILE=my-profile
$ traceroute53 example.com 
$ # traceroute53 --profile my-profile example.com
```

See also:
- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
- https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#general-options